### PR TITLE
Add Arabic trivia game skeleton

### DIFF
--- a/Labatna/LabatnaApp.swift
+++ b/Labatna/LabatnaApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@main
+struct LabatnaApp: App {
+    @StateObject private var gameViewModel = GameViewModel()
+    @Environment(\.layoutDirection) var layoutDirection
+
+    init() {
+        UIView.appearance().semanticContentAttribute = .forceRightToLeft
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            SplashView()
+                .environmentObject(gameViewModel)
+        }
+    }
+}

--- a/Labatna/Models/Category.swift
+++ b/Labatna/Models/Category.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Category: Identifiable {
+    let id = UUID()
+    let name: String
+    var questions: [Question]
+}

--- a/Labatna/Models/Question.swift
+++ b/Labatna/Models/Question.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Question: Identifiable {
+    let id = UUID()
+    let text: String
+    let value: Int
+    let imageName: String?
+    let answer: String
+}

--- a/Labatna/ViewModels/GameViewModel.swift
+++ b/Labatna/ViewModels/GameViewModel.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+final class GameViewModel: ObservableObject {
+    @Published var teams: [String] = ["الفريق أ", "الفريق ب"]
+    @Published var selectedCategories: [Category] = []
+    @Published var currentQuestion: Question?
+    @Published var scores: [Int] = [0, 0]
+    @Published var showHome: Bool = false
+
+    let allCategories: [Category] = [
+        Category(name: "رياضة", questions: []),
+        Category(name: "تاريخ", questions: []),
+        Category(name: "علوم", questions: []),
+        Category(name: "جغرافيا", questions: []),
+        Category(name: "أدب", questions: []),
+        Category(name: "فن", questions: []),
+        Category(name: "تكنولوجيا", questions: []),
+        Category(name: "أفلام", questions: []),
+        Category(name: "موسيقى", questions: []),
+        Category(name: "متفرقات", questions: [])
+    ]
+
+    func startGame() {
+        scores = [0, 0]
+        currentQuestion = nil
+    }
+
+    func selectCategory(_ category: Category) {
+        if selectedCategories.count < 6 {
+            selectedCategories.append(category)
+        }
+    }
+
+    func nextQuestion() {
+        guard let category = selectedCategories.randomElement() else { return }
+        guard let question = category.questions.randomElement() else { return }
+        currentQuestion = question
+    }
+
+    func answerQuestion(correct: Bool, value: Int, teamIndex: Int) {
+        if correct {
+            scores[teamIndex] += value
+        } else {
+            scores[teamIndex] -= value
+        }
+    }
+}

--- a/Labatna/Views/AdminPanelView.swift
+++ b/Labatna/Views/AdminPanelView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct AdminPanelView: View {
+    var body: some View {
+        Text("لوحة التحكم (قريباً)")
+            .font(.headline)
+            .padding()
+            .background(Color("Background"))
+    }
+}
+
+struct AdminPanelView_Previews: PreviewProvider {
+    static var previews: some View {
+        AdminPanelView()
+    }
+}

--- a/Labatna/Views/AnswerRevealView.swift
+++ b/Labatna/Views/AnswerRevealView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct AnswerRevealView: View {
+    @EnvironmentObject var game: GameViewModel
+    @Environment(\.dismiss) var dismiss
+    let value: Int
+    let teamIndex: Int
+    @State private var correct = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            if let question = game.currentQuestion {
+                Text("الإجابة الصحيحة: \(question.answer)")
+                Toggle("إجابة صحيحة؟", isOn: $correct)
+                    .toggleStyle(SwitchToggleStyle(tint: Color("Button")))
+            }
+            Button("تأكيد") {
+                game.answerQuestion(correct: correct, value: value, teamIndex: teamIndex)
+                dismiss()
+            }
+            .buttonStyle(MainButtonStyle())
+        }
+        .padding()
+        .background(Color("Background").edgesIgnoringSafeArea(.all))
+    }
+}
+
+struct AnswerRevealView_Previews: PreviewProvider {
+    static var previews: some View {
+        AnswerRevealView(value: 200, teamIndex: 0).environmentObject(GameViewModel())
+    }
+}

--- a/Labatna/Views/CategorySelectionView.swift
+++ b/Labatna/Views/CategorySelectionView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct CategorySelectionView: View {
+    @EnvironmentObject var game: GameViewModel
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 120))], spacing: 20) {
+                ForEach(game.allCategories) { category in
+                    CategoryCard(category: category)
+                        .onTapGesture {
+                            game.selectCategory(category)
+                        }
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(game.selectedCategories.contains(where: { $0.id == category.id }) ? Color("Button") : Color.clear, lineWidth: 3)
+                        )
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("اختر الفئات (\(game.selectedCategories.count)/6)")
+        .toolbar {
+            NavigationLink(destination: GameBoardView()) {
+                Text("التالي")
+                    .bold()
+            }.disabled(game.selectedCategories.count < 6)
+        }
+        .background(Color("Background").edgesIgnoringSafeArea(.all))
+    }
+}
+
+struct CategoryCard: View {
+    let category: Category
+
+    var body: some View {
+        VStack {
+            Image(systemName: "questionmark")
+                .resizable()
+                .scaledToFit()
+                .frame(height: 60)
+                .foregroundColor(Color("Button"))
+            Text(category.name)
+                .font(.headline)
+                .foregroundColor(Color("Button"))
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(Color.white.opacity(0.8))
+        .cornerRadius(10)
+        .shadow(color: .black.opacity(0.1), radius: 5, x: 0, y: 2)
+    }
+}
+
+struct CategorySelectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            CategorySelectionView().environmentObject(GameViewModel())
+        }
+    }
+}

--- a/Labatna/Views/Components/Color+Theme.swift
+++ b/Labatna/Views/Components/Color+Theme.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension Color {
+    static let appBackground = Color(red: 0.93, green: 0.90, blue: 0.85)
+    static let buttonColor = Color(red: 0.0, green: 0.45, blue: 0.3)
+}
+extension Color {
+    init(_ name: String) {
+        switch name {
+        case "Background": self = .appBackground
+        case "Button": self = .buttonColor
+        default: self = Color(name)
+        }
+    }
+}

--- a/Labatna/Views/Components/MainButton.swift
+++ b/Labatna/Views/Components/MainButton.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct MainButton: View {
+    let title: String
+    var action: (() -> Void)? = nil
+
+    var body: some View {
+        Button(action: { action?() }) {
+            Text(title)
+                .font(.headline)
+                .foregroundColor(.white)
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(Color("Button"))
+                .cornerRadius(12)
+                .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
+        }
+        .buttonStyle(MainButtonStyle())
+    }
+}
+
+struct MainButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .opacity(configuration.isPressed ? 0.8 : 1)
+            .animation(.easeInOut(duration: 0.2), value: configuration.isPressed)
+    }
+}

--- a/Labatna/Views/GameBoardView.swift
+++ b/Labatna/Views/GameBoardView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct GameBoardView: View {
+    @EnvironmentObject var game: GameViewModel
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: Array(repeating: .init(.flexible()), count: game.selectedCategories.count), spacing: 10) {
+                ForEach(game.selectedCategories) { category in
+                    VStack {
+                        Text(category.name)
+                            .font(.headline)
+                        ForEach([200, 400, 800, 1600], id: \.self) { value in
+                            NavigationLink(destination: QuestionView(category: category, value: value)) {
+                                Text("\(value)")
+                                    .frame(maxWidth: .infinity)
+                                    .padding(8)
+                                    .background(Color("Button"))
+                                    .foregroundColor(.white)
+                                    .cornerRadius(8)
+                                    .padding(.vertical, 2)
+                            }
+                        }
+                    }
+                    .padding(5)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("لوحة اللعب")
+        .background(Color("Background").edgesIgnoringSafeArea(.all))
+    }
+}
+
+struct GameBoardView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            GameBoardView().environmentObject(GameViewModel())
+        }
+    }
+}

--- a/Labatna/Views/HomeView.swift
+++ b/Labatna/Views/HomeView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct HomeView: View {
+    @EnvironmentObject var game: GameViewModel
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color("Background").edgesIgnoringSafeArea(.all)
+                VStack(spacing: 20) {
+                    NavigationLink(destination: TeamRegistrationView()) {
+                        MainButton(title: "العب الآن")
+                    }
+                    NavigationLink(destination: ScoreView()) {
+                        MainButton(title: "الفرق")
+                    }
+                    NavigationLink(destination: ScoreView()) {
+                        MainButton(title: "المركز")
+                    }
+                    NavigationLink(destination: SettingsView()) {
+                        MainButton(title: "الإعدادات")
+                    }
+                }
+            }
+            .navigationBarHidden(true)
+        }
+    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView().environmentObject(GameViewModel())
+    }
+}

--- a/Labatna/Views/QuestionView.swift
+++ b/Labatna/Views/QuestionView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct QuestionView: View {
+    let category: Category
+    let value: Int
+    @EnvironmentObject var game: GameViewModel
+    @State private var showAnswer = false
+    @State private var answerCorrect = false
+    @State private var teamIndex = 0
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(category.name)
+                .font(.title2)
+            Text("\(value)")
+                .font(.headline)
+            if let question = game.currentQuestion {
+                Text(question.text)
+                    .multilineTextAlignment(.center)
+            }
+            HStack {
+                ForEach(0..<game.teams.count, id: \.self) { index in
+                    Button(game.teams[index]) {
+                        teamIndex = index
+                        showAnswer = true
+                    }
+                    .buttonStyle(MainButtonStyle())
+                }
+            }
+        }
+        .padding()
+        .background(Color("Background").edgesIgnoringSafeArea(.all))
+        .onAppear {
+            game.nextQuestion()
+        }
+        .sheet(isPresented: $showAnswer) {
+            AnswerRevealView(value: value, teamIndex: teamIndex)
+        }
+    }
+}
+
+struct QuestionView_Previews: PreviewProvider {
+    static var previews: some View {
+        QuestionView(category: Category(name: "اختبار", questions: []), value: 200)
+            .environmentObject(GameViewModel())
+    }
+}

--- a/Labatna/Views/ScoreView.swift
+++ b/Labatna/Views/ScoreView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct ScoreView: View {
+    @EnvironmentObject var game: GameViewModel
+
+    var body: some View {
+        VStack(spacing: 20) {
+            ForEach(0..<game.teams.count, id: \.self) { index in
+                HStack {
+                    Text(game.teams[index])
+                        .font(.title3)
+                    Spacer()
+                    Text("\(game.scores[index])")
+                        .bold()
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.white.opacity(0.8))
+                .cornerRadius(10)
+                .shadow(radius: 2)
+            }
+        }
+        .padding()
+        .background(Color("Background").edgesIgnoringSafeArea(.all))
+    }
+}
+
+struct ScoreView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScoreView().environmentObject(GameViewModel())
+    }
+}

--- a/Labatna/Views/SettingsView.swift
+++ b/Labatna/Views/SettingsView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var soundOn = true
+    @State private var musicOn = true
+
+    var body: some View {
+        Form {
+            Toggle("الصوت", isOn: $soundOn)
+            Toggle("الموسيقى", isOn: $musicOn)
+            NavigationLink("الدعم والمساعدة") {
+                Text("Coming Soon")
+            }
+        }
+        .navigationTitle("الإعدادات")
+        .background(Color("Background"))
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            SettingsView()
+        }
+    }
+}

--- a/Labatna/Views/SplashView.swift
+++ b/Labatna/Views/SplashView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+struct SplashView: View {
+    @State private var animate = false
+    @EnvironmentObject var game: GameViewModel
+
+    var body: some View {
+        ZStack {
+            Color("Background").edgesIgnoringSafeArea(.all)
+            VStack {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 80))
+                    .foregroundColor(Color("Button"))
+                    .opacity(animate ? 1 : 0)
+                    .scaleEffect(animate ? 1 : 0.5)
+                    .animation(.easeOut(duration: 1), value: animate)
+                Text("لعبتنا")
+                    .font(.largeTitle.bold())
+                    .foregroundColor(Color("Button"))
+                    .opacity(animate ? 1 : 0)
+                    .animation(.easeOut(duration: 1.5), value: animate)
+            }
+        }
+        .onAppear {
+            animate = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                game.showHome = true
+            }
+        }
+        .fullScreenCover(isPresented: $game.showHome) {
+            HomeView()
+        }
+    }
+}
+
+struct SplashView_Previews: PreviewProvider {
+    static var previews: some View {
+        SplashView().environmentObject(GameViewModel())
+    }
+}

--- a/Labatna/Views/TeamRegistrationView.swift
+++ b/Labatna/Views/TeamRegistrationView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct TeamRegistrationView: View {
+    @EnvironmentObject var game: GameViewModel
+    @State private var teamA: String = ""
+    @State private var teamB: String = ""
+    @State private var navigate = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            TextField("اسم الفريق أ", text: $teamA)
+                .textFieldStyle(.roundedBorder)
+            TextField("اسم الفريق ب", text: $teamB)
+                .textFieldStyle(.roundedBorder)
+            NavigationLink(destination: CategorySelectionView(), isActive: $navigate) {
+                EmptyView()
+            }
+            MainButton(title: "ابدأ اللعبة") {
+                game.teams = [teamA.isEmpty ? "الفريق أ" : teamA,
+                              teamB.isEmpty ? "الفريق ب" : teamB]
+                navigate = true
+            }
+        }
+        .padding()
+        .background(Color("Background").edgesIgnoringSafeArea(.all))
+    }
+}
+
+struct TeamRegistrationView_Previews: PreviewProvider {
+    static var previews: some View {
+        TeamRegistrationView().environmentObject(GameViewModel())
+    }
+}

--- a/Labatna/Views/WinnerView.swift
+++ b/Labatna/Views/WinnerView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct WinnerView: View {
+    let winner: String
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("الفائز هو")
+                .font(.largeTitle)
+            Text(winner)
+                .font(.title)
+                .bold()
+            Image(systemName: "sparkles")
+                .font(.system(size: 80))
+                .foregroundColor(Color("Button"))
+                .scaleEffect(1.2)
+                .animation(.easeInOut.repeatForever(), value: true)
+        }
+        .padding()
+        .background(Color("Background").edgesIgnoringSafeArea(.all))
+    }
+}
+
+struct WinnerView_Previews: PreviewProvider {
+    static var previews: some View {
+        WinnerView(winner: "الفريق أ")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# esam-alshammari
+# لعبتنا - Trivia Game (SwiftUI)
+
+A minimal SwiftUI project for an Arabic trivia game inspired by "سين جيم". The app demonstrates category selection, question display, scoring, and smooth right-to-left UI.
+
+## Structure
+- `LabatnaApp.swift` – app entry point.
+- `Models` – simple data models for questions and categories.
+- `ViewModels` – `GameViewModel` handling game logic and state.
+- `Views` – SwiftUI screens for splash, home, registration, gameplay, and settings.
+
+This project is a starting point for a fully featured game. It focuses on a clean code structure, reusable components, and modern SwiftUI design.


### PR DESCRIPTION
## Summary
- create SwiftUI app skeleton for Arabic trivia game "لعبتنا"
- add main views like SplashView, HomeView, registration, categories and questions
- implement reusable components and color theme
- update README with project overview

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6846146ff5c4832499a22866c27c5c30